### PR TITLE
Enable Star Colour Change

### DIFF
--- a/src/idea.js
+++ b/src/idea.js
@@ -12,7 +12,12 @@ class Idea {
 
   }
   updateIdea() {
-
+    this.star = !this.star;
+    if (this.star) {
+      return "assets/star-active.svg";
+    }
+    else {
+      return "assets/star.svg";
+    }
   }
-
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,18 +2,18 @@ var hamburgerButton = document.querySelector(".hamburger-button");
 var showStarredButton = document.querySelector(".show-starred");
 var saveIdeaButton = document.querySelector(".save-idea-button");
 var searchIdeaButton = document.querySelector(".search-idea-button");
-var ideaStar = document.querySelector(".box-star");
-var ideaDelete = document.querySelector(".box-x");
 var titleInput = document.querySelector(".title-input");
 var bodyInput = document.querySelector(".body-input");
 var searchInput = document.querySelector(".search-idea-input");
-var deleteCard = document.querySelector(".box-x");
 //possible local selectors below
 var ideaCardArea = document.querySelector(".idea-cards");
 
 var savedIdeas = [];
 
-window.addEventListener("click", clickHandler);
+window.addEventListener("click", function(event) {
+  clickHandler(event);
+  removeCard(event);
+});
 window.addEventListener("keyup", keyHandler);
 
 function clickHandler(event) {
@@ -25,16 +25,19 @@ function clickHandler(event) {
     bodyInput.value = "";
     disableButton();
   }
-  if (event.target === deleteCard) {
+}
 
-    // local variable set to the event.target.id
-    for (var i = 0; i < savedIdeas.length; i++) {
-      // if the  id == the savedIdeas[i] id
-      // then splice savedIdeas[i] out of savedIdeas
-      // .remove savedIdeas[i] out of savedIdeas array
-    }
+function removeCard(event) {
+  if (event.target.className === "box-x") {
+    console.log("hi");
   }
-};
+}
+  // local variable set to the event.target.id
+  // for (var i = 0; i < savedIdeas.length; i++) {
+    // if the  id == the savedIdeas[i] id
+    // then splice savedIdeas[i] out of savedIdeas
+    // .remove savedIdeas[i] out of savedIdeas array
+  // }
 
 // if deleteCard === target
 // loop through savedIdeas

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ var ideaDelete = document.querySelector(".box-x");
 var titleInput = document.querySelector(".title-input");
 var bodyInput = document.querySelector(".body-input");
 var searchInput = document.querySelector(".search-idea-input");
+var deleteCard = document.querySelector(".box-x");
 //possible local selectors below
 var ideaCardArea = document.querySelector(".idea-cards");
 
@@ -19,27 +20,40 @@ function clickHandler(event) {
   if (titleInput.value !== "" && bodyInput.value !== "" && event.target === saveIdeaButton) {
     var newIdea = new Idea(titleInput.value, bodyInput.value);
     savedIdeas.push(newIdea);
-    displayIdeas();
+    displayIdeas(newIdea);
     titleInput.value = "";
     bodyInput.value = "";
     disableButton();
   }
+  if (event.target === deleteCard) {
+
+    // local variable set to the event.target.id
+    for (var i = 0; i < savedIdeas.length; i++) {
+      // if the  id == the savedIdeas[i] id
+      // then splice savedIdeas[i] out of savedIdeas
+      // .remove savedIdeas[i] out of savedIdeas array
+    }
+  }
 };
 
+// if deleteCard === target
+// loop through savedIdeas
+// splice target saved idea index out of savedIdeas array
+// .remove() the target
 function keyHandler(){
   titleInput.value !== "" && bodyInput.value !== "" ? enableButton() : disableButton();
 }
 
-function displayIdeas() {
+function displayIdeas(newIdea) {
   var savedIdeaCard = `
-    <div class="idea-box">
+    <div class="idea-box" ${newIdea.id}>
       <div class="box-header">
         <img src="assets/star-active.svg" alt="Star Icon" class="box-star">
         <img src="assets/delete.svg" alt="Delete Icon" class="box-x">
       </div>
       <div>
-        <h2 class="header-text">${titleInput.value}</h2>
-        <p class="body-text">${bodyInput.value}</p>
+        <h2 class="header-text">${newIdea.title}</h2>
+        <p class="body-text">${newIdea.body}</p>
       </div>
       <div class=" box-footer">
         <img src="assets/comment.svg" alt="Add Comment Icon">

--- a/src/main.js
+++ b/src/main.js
@@ -54,8 +54,8 @@ function toggleStars(event) {
   } else {
     event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg"
   }
-  
-  console.log(event.target.src)
+
+  console.log(event.target)
   // event.target.src = "box-star"
 
   // inactive.classList.add("hidden");

--- a/src/main.js
+++ b/src/main.js
@@ -23,9 +23,8 @@ window.addEventListener("keyup", keyHandler);
 function createIdeaCard(event) {
     var newIdea = new Idea(titleInput.value, bodyInput.value);
     savedIdeas.push(newIdea);
+    clearFields();
     displayIdeas(newIdea);
-    titleInput.value = "";
-    bodyInput.value = "";
     disableButton();
 };
 
@@ -38,6 +37,11 @@ function removeCard(event) {
         selectedIdea.remove();
       }
     }
+  };
+
+  function clearFields() {
+    titleInput.value = ""; //check into a built in method that will do this same thing Only Nifty-er 
+    bodyInput.value = "";
   };
 
 function keyHandler(){

--- a/src/main.js
+++ b/src/main.js
@@ -30,13 +30,12 @@ function clickHandler(event) {
 
 function removeCard(event) {
   if (event.target.className === "box-x") {
-    var selectedIdea2 = event.target.closest("idea-box");
-    var selectedIdea = event.target.id;
-    // console.log(selectedIdea2);
+    var selectedIdea = event.target.closest(".idea-box");
+    var selectedID = event.target.id;
     for (var i = 0; i < savedIdeas.length; i++) {
-      if (savedIdeas[i].id == selectedIdea) {
+      if (savedIdeas[i].id == selectedID) {
         savedIdeas.splice(i, 1);
-      selectedIdea2.remove();
+        selectedIdea.remove();
       }
     }
   }

--- a/src/main.js
+++ b/src/main.js
@@ -12,8 +12,9 @@ var savedIdeas = [];
 
 window.addEventListener("click", function(event) {
   clickHandler(event);
-  removeCard(event);
-
+  if (event.target.className === "box-x") {
+    removeCard(event)
+  }
 });
 window.addEventListener("keyup", keyHandler);
 
@@ -26,10 +27,9 @@ function clickHandler(event) {
     bodyInput.value = "";
     disableButton();
   }
-}
+};
 
 function removeCard(event) {
-  if (event.target.className === "box-x") {
     var selectedIdea = event.target.closest(".idea-box");
     var selectedID = event.target.id;
     for (var i = 0; i < savedIdeas.length; i++) {
@@ -38,12 +38,11 @@ function removeCard(event) {
         selectedIdea.remove();
       }
     }
-  }
-}
+  };
 
 function keyHandler(){
   titleInput.value !== "" && bodyInput.value !== "" ? enableButton() : disableButton();
-}
+};
 
 function displayIdeas(newIdea) {
   var savedIdeaCard = `

--- a/src/main.js
+++ b/src/main.js
@@ -48,26 +48,28 @@ function removeCard(event) {
     }
   };
 
-function toggleStars(event) {
-  if (event.target.src == "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg") {
-    event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star-active.svg"
-  } else {
-    event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg"
+
+function toggleStars(event){
+  var selectedIdea = event.target.closest(".idea-box");
+  var selectedID = event.target.id;
+    for (var i = 0; i < savedIdeas.length; i++) {
+      if (savedIdeas[i].id == selectedID) {
+        event.target.src = savedIdeas[i].updateIdea();
   }
+}
+}
 
-  console.log(event.target)
-  // event.target.src = "box-star"
 
-  // inactive.classList.add("hidden");
-  // active.classList.remove("hidden");
-  // var inactiveStar = event.target
-  // var star = event.target.src
-  // star = "assets/star-active.svg"
-  // star.classList.toggle("hidden")
+
+
+  // if (event.target.src == "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg") {
+  //   event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star-active.svg"
+  // } else {
+  //   event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg"
+  // }
+  //
   // console.log(event.target)
-  //if box-star does not have a hidden, give it one onclick, remove hidden from other star
 
-  }
 
   function clearFields() {
     titleInput.value = ""; //check into a built in method that will do this same thing Only Nifty-er
@@ -82,7 +84,7 @@ function displayIdeas(newIdea) {
   var savedIdeaCard = `
     <div class="idea-box">
       <div class="box-header">
-        <img src="assets/star.svg" alt="Inactive Star Icon" class="box-star">
+        <img src="assets/star.svg" alt="Inactive Star Icon" class="box-star" id ="${newIdea.id}">
         <img src="assets/delete.svg" alt="Delete Icon" class="box-x" id="${newIdea.id}">
       </div>
       <div>

--- a/src/main.js
+++ b/src/main.js
@@ -10,74 +10,40 @@ var ideaCardArea = document.querySelector(".idea-cards");
 
 var savedIdeas = [];
 
-//create another html tag for the active red star, apply hidden value to it
-//in the CSS.
-//add conditional to event listener to target the star onclick
-//T O G G L E
-
-
+window.addEventListener("keyup", keyHandler);
 window.addEventListener("click", function(event) {
-  if (event.target.className === "box-x") {
-    removeCard(event);
-  }
   if (titleInput.value !== "" && bodyInput.value !== "" && event.target === saveIdeaButton) {
     createIdeaCard(event);
+  }
+  if (event.target.className === "box-x") {
+    removeCard(event);
   }
   if (event.target.className === "box-star") {
     toggleStars(event);
   }
 });
-window.addEventListener("keyup", keyHandler);
-
-function createIdeaCard(event) {
-    var newIdea = new Idea(titleInput.value, bodyInput.value);
-    savedIdeas.push(newIdea);
-    clearFields();
-    displayIdeas(newIdea);
-    disableButton();
-};
-
-function removeCard(event) {
-    var selectedIdea = event.target.closest(".idea-box");
-    var selectedID = event.target.id;
-    for (var i = 0; i < savedIdeas.length; i++) {
-      if (savedIdeas[i].id == selectedID) {
-        savedIdeas.splice(i, 1);
-        selectedIdea.remove();
-      }
-    }
-  };
-
-
-function toggleStars(event){
-  var selectedIdea = event.target.closest(".idea-box");
-  var selectedID = event.target.id;
-    for (var i = 0; i < savedIdeas.length; i++) {
-      if (savedIdeas[i].id == selectedID) {
-        event.target.src = savedIdeas[i].updateIdea();
-  }
-}
-}
-
-
-
-
-  // if (event.target.src == "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg") {
-  //   event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star-active.svg"
-  // } else {
-  //   event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg"
-  // }
-  //
-  // console.log(event.target)
-
-
-  function clearFields() {
-    titleInput.value = ""; //check into a built in method that will do this same thing Only Nifty-er
-    bodyInput.value = "";
-  };
 
 function keyHandler(){
   titleInput.value !== "" && bodyInput.value !== "" ? enableButton() : disableButton();
+};
+
+function createIdeaCard(event) {
+  var newIdea = new Idea(titleInput.value, bodyInput.value);
+  savedIdeas.push(newIdea);
+  clearFields();
+  displayIdeas(newIdea);
+  disableButton();
+};
+
+function removeCard(event) {
+  var selectedIdea = event.target.closest(".idea-box");
+  var selectedID = event.target.id;
+  for (var i = 0; i < savedIdeas.length; i++) {
+    if (savedIdeas[i].id == selectedID) {
+      savedIdeas.splice(i, 1);
+      selectedIdea.remove();
+    }
+  }
 };
 
 function displayIdeas(newIdea) {
@@ -95,11 +61,25 @@ function displayIdeas(newIdea) {
         <img src="assets/comment.svg" alt="Add Comment Icon">
         <h3 class="header-text">Comment</h3>
       </div>
-    </div>
-  `;
+    </div>`;
   ideaCardArea.insertAdjacentHTML("afterbegin", savedIdeaCard);
 };
-//
+
+function toggleStars(event){
+  var selectedIdea = event.target.closest(".idea-box");
+  var selectedID = event.target.id;
+    for (var i = 0; i < savedIdeas.length; i++) {
+      if (savedIdeas[i].id == selectedID) {
+        event.target.src = savedIdeas[i].updateIdea();
+    }
+  }
+};
+
+function clearFields() {
+  titleInput.value = ""; //check into a built in method that will do this same thing Only Nifty-er
+  bodyInput.value = "";
+};
+
 function enableButton(){
   saveIdeaButton.classList.add("save-idea-active");
 };

--- a/src/main.js
+++ b/src/main.js
@@ -10,12 +10,21 @@ var ideaCardArea = document.querySelector(".idea-cards");
 
 var savedIdeas = [];
 
+//create another html tag for the active red star, apply hidden value to it
+//in the CSS.
+//add conditional to event listener to target the star onclick
+//T O G G L E
+
+
 window.addEventListener("click", function(event) {
   if (event.target.className === "box-x") {
     removeCard(event);
   }
   if (titleInput.value !== "" && bodyInput.value !== "" && event.target === saveIdeaButton) {
     createIdeaCard(event);
+  }
+  if (event.target.className === "box-star") {
+    toggleStars(event);
   }
 });
 window.addEventListener("keyup", keyHandler);
@@ -39,8 +48,29 @@ function removeCard(event) {
     }
   };
 
+function toggleStars(event) {
+  if (event.target.src == "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg") {
+    event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star-active.svg"
+  } else {
+    event.target.src = "file:///Users/brigette.doelp/turing/mod1repeat/ideabox-boilerplate/assets/star.svg"
+  }
+  
+  console.log(event.target.src)
+  // event.target.src = "box-star"
+
+  // inactive.classList.add("hidden");
+  // active.classList.remove("hidden");
+  // var inactiveStar = event.target
+  // var star = event.target.src
+  // star = "assets/star-active.svg"
+  // star.classList.toggle("hidden")
+  // console.log(event.target)
+  //if box-star does not have a hidden, give it one onclick, remove hidden from other star
+
+  }
+
   function clearFields() {
-    titleInput.value = ""; //check into a built in method that will do this same thing Only Nifty-er 
+    titleInput.value = ""; //check into a built in method that will do this same thing Only Nifty-er
     bodyInput.value = "";
   };
 
@@ -52,7 +82,7 @@ function displayIdeas(newIdea) {
   var savedIdeaCard = `
     <div class="idea-box">
       <div class="box-header">
-        <img src="assets/star-active.svg" alt="Star Icon" class="box-star">
+        <img src="assets/star.svg" alt="Inactive Star Icon" class="box-star">
         <img src="assets/delete.svg" alt="Delete Icon" class="box-x" id="${newIdea.id}">
       </div>
       <div>
@@ -67,7 +97,7 @@ function displayIdeas(newIdea) {
   `;
   ideaCardArea.insertAdjacentHTML("afterbegin", savedIdeaCard);
 };
-
+//
 function enableButton(){
   saveIdeaButton.classList.add("save-idea-active");
 };

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ var savedIdeas = [];
 window.addEventListener("click", function(event) {
   clickHandler(event);
   removeCard(event);
+
 });
 window.addEventListener("keyup", keyHandler);
 
@@ -29,7 +30,15 @@ function clickHandler(event) {
 
 function removeCard(event) {
   if (event.target.className === "box-x") {
-    console.log("hi");
+    var selectedIdea2 = event.target.closest("idea-box");
+    var selectedIdea = event.target.id;
+    // console.log(selectedIdea2);
+    for (var i = 0; i < savedIdeas.length; i++) {
+      if (savedIdeas[i].id == selectedIdea) {
+        savedIdeas.splice(i, 1);
+      selectedIdea2.remove();
+      }
+    }
   }
 }
   // local variable set to the event.target.id
@@ -49,10 +58,10 @@ function keyHandler(){
 
 function displayIdeas(newIdea) {
   var savedIdeaCard = `
-    <div class="idea-box" ${newIdea.id}>
+    <div class="idea-box">
       <div class="box-header">
         <img src="assets/star-active.svg" alt="Star Icon" class="box-star">
-        <img src="assets/delete.svg" alt="Delete Icon" class="box-x">
+        <img src="assets/delete.svg" alt="Delete Icon" class="box-x" id="${newIdea.id}">
       </div>
       <div>
         <h2 class="header-text">${newIdea.title}</h2>

--- a/src/main.js
+++ b/src/main.js
@@ -11,22 +11,22 @@ var ideaCardArea = document.querySelector(".idea-cards");
 var savedIdeas = [];
 
 window.addEventListener("click", function(event) {
-  clickHandler(event);
   if (event.target.className === "box-x") {
-    removeCard(event)
+    removeCard(event);
+  }
+  if (titleInput.value !== "" && bodyInput.value !== "" && event.target === saveIdeaButton) {
+    createIdeaCard(event);
   }
 });
 window.addEventListener("keyup", keyHandler);
 
-function clickHandler(event) {
-  if (titleInput.value !== "" && bodyInput.value !== "" && event.target === saveIdeaButton) {
+function createIdeaCard(event) {
     var newIdea = new Idea(titleInput.value, bodyInput.value);
     savedIdeas.push(newIdea);
     displayIdeas(newIdea);
     titleInput.value = "";
     bodyInput.value = "";
     disableButton();
-  }
 };
 
 function removeCard(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -40,17 +40,7 @@ function removeCard(event) {
     }
   }
 }
-  // local variable set to the event.target.id
-  // for (var i = 0; i < savedIdeas.length; i++) {
-    // if the  id == the savedIdeas[i] id
-    // then splice savedIdeas[i] out of savedIdeas
-    // .remove savedIdeas[i] out of savedIdeas array
-  // }
 
-// if deleteCard === target
-// loop through savedIdeas
-// splice target saved idea index out of savedIdeas array
-// .remove() the target
 function keyHandler(){
   titleInput.value !== "" && bodyInput.value !== "" ? enableButton() : disableButton();
 }

--- a/styles.css
+++ b/styles.css
@@ -237,7 +237,11 @@ hr {
   border: 1px solid #6E646B;
 }
 
-.box-star {
+.hidden {
+  display: none;
+}
+
+.box-star, .active-box-star {
   height: 3em;
   width: 3em;
 }


### PR DESCRIPTION
### What’s this PR do? 
It enables the functionality of the 'favourite star' button. When it is white and clicked, the star will become orange, and the status of the object's this.star key value pair will become true. If the star is orange and is clicked, the star will revert to white and the value of the this.star key value pair will revert to the default of false.

This PR also removes various pseudocode comments and adjusts indentation to fit with the given style guide.
​
### Where should the reviewer start?
In the idea.js file. On line 14, with the updateStar() method. Then, the reviewer will reference the function toggleStars() beginning on line 68.

After, if the reviewer could skim the main.js file for inconsistencies in js styling, that would be swell.
​
### How should this be manually tested?
By opening index.html or opening the github pages link. From there, create a card and when it is created, click on the star. 

### What are the relevant tickets?
There will be a branch for CSS to address the problem of the page styling to stretching to the entire window.
​
### Screenshots (if appropriate): 
​![stargif](https://i.imgur.com/FzGzdOR.gif)